### PR TITLE
Update screenshot.rb

### DIFF
--- a/lib/webshot/screenshot.rb
+++ b/lib/webshot/screenshot.rb
@@ -45,7 +45,7 @@ module Webshot
         sleep opts[:timeout] if opts[:timeout]
 
         # Check response code
-        if page.driver.status_code == 200
+        if page.driver.status_code == 200 || page.driver.status_code / 100 == 3
           tmp = Tempfile.new(["webshot", ".png"])
           tmp.close
           begin


### PR DESCRIPTION
This should handle redirect error codes. Capybara will follow the redirect; the screenshot is correct in this given scenario.
