### PR TITLE
Update Mini_magick and Poltergeist gems

### DIFF
--- a/lib/webshot/screenshot.rb
+++ b/lib/webshot/screenshot.rb
@@ -76,7 +76,7 @@ module Webshot
         else
           raise WebshotError.new("Could not fetch page: #{url.inspect}, error code: #{page.driver.status_code}")
         end
-      rescue Capybara::Poltergeist::BrowserError, Capybara::Poltergeist::DeadClient, Capybara::Poltergeist::TimeoutError, Errno::EPIPE => e
+      rescue Capybara::Poltergeist::StatusFailError, Capybara::Poltergeist::BrowserError, Capybara::Poltergeist::DeadClient, Capybara::Poltergeist::TimeoutError, Errno::EPIPE => e
         # TODO: Handle Errno::EPIPE and Errno::ECONNRESET
         raise WebshotError.new("Capybara error: #{e.message.inspect}")
       end

--- a/webshot.gemspec
+++ b/webshot.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "gem-release"
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "poltergeist", "~> 1.5.0"
+  spec.add_dependency "poltergeist", "~> 1.6.0"
   spec.add_dependency "faye-websocket", "~> 0.7.3"
   spec.add_dependency "mini_magick", "~> 3.7.0"
 end

--- a/webshot.gemspec
+++ b/webshot.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "poltergeist", "~> 1.6.0"
   spec.add_dependency "faye-websocket", "~> 0.7.3"
-  spec.add_dependency "mini_magick", "~> 3.7.0"
+  spec.add_dependency "mini_magick", "~> 4.3.3"
 end


### PR DESCRIPTION
Updates:

  - Poltergeist to 1.6.0
  - Mini_magick to 4.3.3

A new exception is captured (Capybara::Poltergeist::StatusFailError) to pass the test "test_invalid_url".

Regards