### PR TITLE
Update mini_magick to ~4.9

### DIFF
--- a/webshot.gemspec
+++ b/webshot.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "poltergeist", [">= 1.12.0", "<= 1.18.1"]
   spec.add_dependency "faye-websocket", [">= 0.7.3", "<= 0.10.9"]
-  spec.add_dependency "mini_magick", "~> 4.3"
+  spec.add_dependency "mini_magick", "~> 4.9"
 end


### PR DESCRIPTION
There's some security vulnerabilities related to mini_magick, that are addressed in 4.9.4.

> [CVE-2019-13574](https://nvd.nist.gov/vuln/detail/CVE-2019-13574)
> `high severity`
> Vulnerable versions: < 4.9.4
> Patched version: 4.9.4
> 
> In lib/mini_magick/image.rb in MiniMagick before 4.9.4, a fetched remote image filename could cause remote command execution because Image.open input is directly passed to Kernel#open, which accepts a '|' character followed by a command.

It is a minor version bump, so theoretically it should be fine, but I honestly don't know enough about this project at the moment to know the full implications of the changes (sorry).
[full changelog](https://github.com/minimagick/minimagick/releases)
<details>
  <summary>(copied here for convenience)</summary>

## v4.9.5
- Fixed MiniMagick::Image.open not working with non-ASCII filenames

## v4.9.4
- Fixed a remote shell execution vulnerability when using MiniMagick::Image.open with URL coming from unsanitized user input
- Fixed some Ruby warnings

## v4.9.3
- make MiniMagick::Tool not respond to everything

## v4.9.2
- Fix breakage for MRI 2.3 and below

## v4.9.1
- Properly handle EXIF parsing with ImageMagick 7
- Show an informative exception message on Timeout::Error
- Wait for the MiniMagick command to terminate after sending SIGTERM with open3

## v4.9.0
- Support ImageMagick 7
  - MiniMagick::Tool::Convert will now generate magick convert commands (and the same for others)
  - MiniMagick::Tool::Magick was added for generating magick commands
- MiniMagick.cli_prefix was added to configure a prefix for commands
- Fix deadlocks when using posix-spawn as a shell backend
- Fix Errno::ESRCH sometimes being raised when the ImageMagick command would time out
- #label and #caption will now generate regular options
- Add pango creation operator
- Handle GraphicsMagick returning unknown in EXIF data

## v4.8.0
- Add options to MiniMagick::Image.open which are forwarded to open-uri when URL is used
- Fixed MiniMagick::Image#get_pixels not returning all pixels for images that have first or last bytes that could be interpreted as control characters in their RGB output

## v4.7.2
- Avoid defining methods at runtime whenever a processing method is invoked, which means that Ruby can keep its method cache, instead of having to clear it on each processing invocation

## v4.7.1
- Fix errors when calling MiniMagick::Image.open with URLs like https://pbs.twimg.com/media/DCOD2DXVwAI4xsL.jpg:large, where the : would get included in the file extension and cause errors with some ImageMagick commands due to : being a special character to ImageMagick

## v4.7.0
- Added MiniMagick::Image#get_pixels, which returns a matrix where each member is a 3-element array of numbers between 0 and 255, one for each of the RGB channels
- When MiniMagick.timeout is set and the command times out, previously the command would still continue running in the background. Now when Timeout::Error is raised, we also kill the subprocess running the command with SIGTERM
- Implementation of posix-spawn has been improved, where now both stdout and stderr are read from at the same time, stdin pipe is closed immediately after writing the input, and stdout and stderr pipes are closed once the command finishes. This now has essentially the same behaivour as Open3.popen3 with a block

## v4.6.1
- Fixed MiniMagick::Image#data to be work for multilayer images where array is returned as the JSON representation
- Fixed stdout and stderr buffer overload that can happen when processing many images using posix-spawn

## v4.6.0
- Fix Image#exif raising an error when an exif value contains a "=" chracter
- Fix Image#exif raising an error when an exif value spans on multiple lines
- Introduced Image#data as an alternative to Image#details, which uses ImageMagick's ability to retrieve identify -verbose output in JSON format. This eliminates possibility of any parsing errors. It is available on ImageMagick 6.8.8-3 or above
- Allow Image#format to accept a hash of options as a third argument, which will be added to the convert command before original path is added
- Support Pathname in Image.new, as we already supported Pathname in Image.open
- Added Tool#stdout which adds - to the command (the same as Tool#stdin does)

## v4.5.1
- Fixed MiniMagick logging commands by default

## v4.5.0
- Added the ability for ImageMagick commands to accept standard input
- Added ability to capture stdout, stderr and exist status by passing a block to MiniMagick::Tool#call
- Added ability to assign MiniMagick.logger to Rails.logger
- The value of MiniMagick.whiny configuration option is now respected
- The new filename when calling #format is now generated better when calling on a layer
- Delete *.cache files generated by .mpc files when deleting MiniMagick::Image
- Whiny option should now be passed as a keyword argument
- Passing the whiny argument to MiniMagick::Tool#call is deprecated, it should now always be passed to MiniMagick::Tool.new

## v4.4.0
- Using MiniMagick::Image#format now works when the image instance is a layer/frame/page
- Calling MiniMagick::Tool#clone as a way of adding the -clone CLI option now works properly (before it would call Object#clone)
- Badly encoded lines in identify -verbose don't cause an error anymore in MiniMagick::Image#details
- MiniMagick::Image#details doesn't hang anymore when clipping paths are present
- Added MiniMagick::Image#tempfile for accessing the underlying temporary file
</details>